### PR TITLE
Radix uptree operation should cache the result, so it doesn't need to…

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
   "license": "BSD",
   "tags": ["serialization","loading","saving","storage","database","network"],
   "description": "Haxe Serialization Library",
-  "version": "0.2.0",
-  "releasenote": "Adding enum versioning support. Optional Radix tree string compression",
-  "contributors": ["Proletariat", "lpetre"]
+  "version": "0.2.1",
+  "releasenote": "Minor optimizations",
+  "contributors": ["Proletariat", "lpetre", "danogles"]
 }

--- a/serialization/internal/RadixTree.hx
+++ b/serialization/internal/RadixTree.hx
@@ -236,6 +236,10 @@ class RadixTree
   }
 
   function uptree(start:RadixNode) : String {
+    if (start.cached != null) {
+      return start.cached;
+    }
+
     var nodes = [];
     var cur = start;
     var root = this.root;
@@ -248,7 +252,8 @@ class RadixTree
     while (i-- > 0) {
       buf.add(nodes[i].data);
     }
-    return buf.toString();
+
+    return start.cached=buf.toString();
   }
 
   inline function createNode(part:String) : RadixNode {
@@ -293,10 +298,12 @@ private class RadixNode
 {
   public var id:Int;
   public var data:String;
+  public var cached:String;
   public var parent:RadixNode;
   public var children:Array<RadixNode>;
 
   public function new(data:String, id:Int) {
+    this.cached = null;
     this.id = id;
     this.data = data;
     this.parent = null;


### PR DESCRIPTION
… rebuild the string each time it is referenced
- [ ] @lpetre 
