### PR TITLE
Don't add the autobuild if we're already processing a macro

### DIFF
--- a/serialization/Deflatable.hx
+++ b/serialization/Deflatable.hx
@@ -32,7 +32,7 @@ import haxe.macro.Type;
 //  - no rtti, add a static method that returns version info
 //  - keep on fields and hxSerialize / hxUnserialize instead of entire class
 
-@:autoBuild(serialization.DeflatableBuild.build())
+#if !macro @:autoBuild(serialization.DeflatableBuild.build()) #end
 interface Deflatable
 {
 }


### PR DESCRIPTION
This was breaking some new code in WorldZombination
